### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,7 +6,7 @@
 # Classes (KEYWORD1)
 ##############################################################
 
-Battery KEYWORD1
+Battery	KEYWORD1
 
 ##############################################################
 # Datatypes (KEYWORD1)
@@ -17,17 +17,17 @@ Battery KEYWORD1
 # Methods and Functions (KEYWORD2)
 ##############################################################
 
-begin KEYWORD2
-init  KEYWORD2
-configureMode KEYWORD2
-configureResolution KEYWORD2
-configureGain KEYWORD2
-getConfigIC KEYWORD2
-getConfigReg  KEYWORD2
-startConversion KEYWORD2
-read  KEYWORD2
-readVoltage KEYWORD2
-readCurrent KEYWORD2
+begin	KEYWORD2
+init	KEYWORD2
+configureMode	KEYWORD2
+configureResolution	KEYWORD2
+configureGain	KEYWORD2
+getConfigIC	KEYWORD2
+getConfigReg	KEYWORD2
+startConversion	KEYWORD2
+read	KEYWORD2
+readVoltage	KEYWORD2
+readCurrent	KEYWORD2
 
 ##############################################################
 # Instances (KEYWORD2)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab, the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords